### PR TITLE
fix: ensure readable stream is closed on empty json and void return types

### DIFF
--- a/.changeset/yummy-signs-peel.md
+++ b/.changeset/yummy-signs-peel.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/lib": patch
+---
+
+ensure readable stream is closed on empty json and void return types

--- a/src/request.ts
+++ b/src/request.ts
@@ -252,12 +252,14 @@ export async function request(input: RequestInfo | URL, config: RequestConfig): 
 			contentType === "json" &&
 			(context.response.status === 204 || context.response.headers.get("content-length") === "0")
 		) {
+			await context.response.body?.cancel();
 			return "";
 		} else if (contentType === "raw") {
 			return context.response;
 		} else if (contentType === "stream") {
 			return context.response.body;
 		} else if (contentType === "void") {
+			await context.response.body?.cancel();
 			return null;
 		}
 


### PR DESCRIPTION
this ensures reading the response's readable stream is canceled when returning with `responseType: "void"` or `responseType: "json"` with an empty response.

when `responseType` is set to "raw" or "stream" it is still the consumer's responsibility to clean up (e.g. either consume or cancel `response.body`).